### PR TITLE
using same peerconnectionfactory

### DIFF
--- a/deps/libmediasoupclient/src/PeerConnection.cpp
+++ b/deps/libmediasoupclient/src/PeerConnection.cpp
@@ -17,8 +17,6 @@
 
 using json = nlohmann::json;
 
-static std::unique_ptr<webrtc::TaskQueueFactory> queueFactory;
-
 namespace mediasoupclient
 {
 	/* Static. */
@@ -96,21 +94,21 @@ namespace mediasoupclient
 				MSC_THROW_INVALID_STATE_ERROR("thread start errored");
 			}
 
-			// auto fakeAudioCaptureModule = FakeAudioCaptureModule::Create();
+			auto fakeAudioCaptureModule = FakeAudioCaptureModule::Create();
 
-			queueFactory = webrtc::CreateDefaultTaskQueueFactory();
+			// std::unique_ptr<webrtc::TaskQueueFactory> queueFactory = webrtc::CreateDefaultTaskQueueFactory();
 
-			auto testAudioCaptureModule = webrtc::TestAudioDeviceModule::Create(queueFactory.get(),
-					webrtc::TestAudioDeviceModule::CreatePulsedNoiseCapturer(32000, 48000, 2),
-					webrtc::TestAudioDeviceModule::CreateDiscardRenderer(48000, 2));
+			// auto testAudioCaptureModule = webrtc::TestAudioDeviceModule::Create(queueFactory.get(),
+			// 		webrtc::TestAudioDeviceModule::CreatePulsedNoiseCapturer(32000, 48000, 2),
+			// 		webrtc::TestAudioDeviceModule::CreateDiscardRenderer(48000, 2));
 
 			this->peerConnectionFactory = webrtc::CreatePeerConnectionFactory(
 			  this->networkThread.get(),
 			  this->workerThread.get(),
 			  this->signalingThread.get(),
 			//   nullptr /*default_adm*/,
-			//   fakeAudioCaptureModule,
-			  testAudioCaptureModule,
+			  fakeAudioCaptureModule,
+			//   testAudioCaptureModule,
 			  webrtc::CreateBuiltinAudioEncoderFactory(),
 			  webrtc::CreateBuiltinAudioDecoderFactory(),
 			  webrtc::CreateBuiltinVideoEncoderFactory(),

--- a/include/Broadcaster.hpp
+++ b/include/Broadcaster.hpp
@@ -38,6 +38,8 @@ private:
 	std::string id = std::to_string(rtc::CreateRandomId());
 	std::string transportId;
 	std::string baseUrl;
+	rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory;
+	
 };
 
 #endif // STOKER_HPP

--- a/include/MediaStreamTrackFactory.hpp
+++ b/include/MediaStreamTrackFactory.hpp
@@ -1,12 +1,16 @@
 #ifndef MSC_TEST_MEDIA_STREAM_TRACK_FACTORY_HPP
 #define MSC_TEST_MEDIA_STREAM_TRACK_FACTORY_HPP
 
+#include "api/create_peerconnection_factory.h"
 #include "api/media_stream_interface.h"
 
-rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(const std::string& label);
+rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> createFactory();
 
-rtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(const std::string& label);
+rtc::scoped_refptr<webrtc::AudioTrackInterface> createAudioTrack(rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory, const std::string& label);
 
-rtc::scoped_refptr<webrtc::VideoTrackInterface> createSquaresVideoTrack(const std::string& label);
+rtc::scoped_refptr<webrtc::VideoTrackInterface> createVideoTrack(rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory, const std::string& label);
+
+rtc::scoped_refptr<webrtc::VideoTrackInterface> createSquaresVideoTrack(rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory, const std::string& label);
+
 
 #endif

--- a/src/Broadcaster.cpp
+++ b/src/Broadcaster.cpp
@@ -131,8 +131,13 @@ void Broadcaster::Start(
 
 	this->baseUrl = baseUrl;
 
+	this->factory = createFactory();
+	mediasoupclient::PeerConnection::Options options;
+	options.factory = factory.get();
+
 	// Load the device.
-	this->device.Load(routerRtpCapabilities);
+	this->device.Load(routerRtpCapabilities, &options);
+
 
 	std::cout << "[INFO] creating Broadcaster..." << std::endl;
 
@@ -224,13 +229,14 @@ void Broadcaster::Start(
 	  this->transportId,
 	  response["iceParameters"],
 	  response["iceCandidates"],
-	  response["dtlsParameters"]);
+	  response["dtlsParameters"],
+	  &options);
 
 	///////////////////////// Create Audio Producer //////////////////////////
 
 	if (enableAudio && this->device.CanProduce("audio"))
 	{
-		auto audioTrack = createAudioTrack(std::to_string(rtc::CreateRandomId()));
+		auto audioTrack = createAudioTrack(factory, std::to_string(rtc::CreateRandomId()));
 
 		/* clang-format off */
 		json codecOptions = {
@@ -250,7 +256,7 @@ void Broadcaster::Start(
 
 	if (this->device.CanProduce("video"))
 	{
-		auto videoTrack = createSquaresVideoTrack(std::to_string(rtc::CreateRandomId()));
+		auto videoTrack = createSquaresVideoTrack(factory, std::to_string(rtc::CreateRandomId()));
 
 		if (useSimulcast)
 		{


### PR DESCRIPTION
Providing the same peerconnectionfactory to device.Load() and device.CreateSendTransport() makes the sound work as expected.